### PR TITLE
refactor!: VC Update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -551,7 +551,7 @@ In order for the issuer to hold a proof that the claimer agreed to the terms, th
 The issuer SHOULD store the signed `RequestAttestation` object in case it is needed for later dispute resolution.
 
 
-The chosen or confirmed DID URI will be submitted as the `subject` field of the `claim` in the `'request-attestation'` message.
+The chosen or confirmed DID URI will be submitted as the `/claim/credentialSubject/id` property in the `'request-attestation'` message.
 The issuer MUST only issue a credential to this DID.
 The issuer MUST use the provided `salt` values for the proof of the credential.
 The issuer MAY reject the request if this DID is different from the `subject` in the previous `'submit-terms'` message.

--- a/readme.md
+++ b/readme.md
@@ -691,7 +691,8 @@ interface RequestCredential {
 
             /**
              * list of credential attributes which MUST be included when submitting the credential.
-             * The properties are identified using JSONPath.
+             * The properties are identified using JSON Pointers:
+             * https://datatracker.ietf.org/doc/html/rfc6901
              */
             requiredProperties: string[]
         }

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,8 @@ Refer to the [kilt-extension-api](https://github.com/KILTprotocol/kilt-extension
 * [IQuote](https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L18)
 * [IQuoteAttesterSigned](https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L30)
 * [IQuoteAgreement](https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L38)
+* [VerifiablePresentation](https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.VerifiablePresentation.html)
+* [KiltCredentialV1](https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.KiltCredentialV1.html)
 
 ### Metadata
 
@@ -521,28 +523,20 @@ interface PaymentConfirmation {
 
 #### 5. Attester submits credential
 
-|              |                        |
-| ------------ | ---------------------- |
-| direction    | `dApp -> extension`    |
-| message_type | `'submit-attestation'` |
+If the attester successfully verified the claim, they SHOULD send a `submit-credential` message.
+This message contains the attested credential.
+To build the credential, the attester will generate the salts which are used in the selective disclosure scheme.
+These salts MUST be used only once and be generated using a cryptographic random generator.
+
+|              |                       |
+| ------------ | --------------------- |
+| direction    | `dApp -> extension`   |
+| message_type | `'submit-credential'` |
 
 ```typescript
-interface Attestation {
-    /** same as the `rootHash` value of the `'request-attestation'` message */
-    claimHash: string
-
-    /** Hash of the CType*/
-    cTypeHash: string
-
-    /** DID URI the credential was issued for */
-    subject: string
-
-    /** optional ID of the DelegationNode of the attester */
-    delegationId?: string
-
-    /** it is expected that the freshly issued credential is not yet revoked */
-    revoked: false
-}
+/** The content of the message is the attested credential.
+ * @link https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.KiltCredentialV1.html */
+type SubmitCredential = KiltCredentialV1
 ```
 
 
@@ -563,7 +557,7 @@ as rejected and SHOULD offer the user the option to remove it.
 
 ```typescript
 /** The contents of the message is simply the `rootHash` of the credential */
-interface AttestationRejection extends string {}
+type AttestationRejection = string
 ```
 
 
@@ -653,7 +647,7 @@ This prevents replay attacks by confirming the ownership of this identity.
 ```typescript
 /** A verifiable presentation.
  *  @link https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.VerifiablePresentation.html */
-interface SubmitCredential extends VerifiablePresentation {}
+type SubmitCredential = VerifiablePresentation
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -252,7 +252,7 @@ interface Message {
 
 #### Quote
 
-```javascript
+```typescript
 interface CostBreakdown {
     tax: Record<string, unknown>
     net: number
@@ -274,7 +274,7 @@ The issuer proposes the content and structure of the credential.
 Since the issuer might not yet know the subjects DID, the `credentialSubject.id` property is optional.
 The credential is also not attested, therefore the `proof` and `issuanceDate` properties are missing.
 
-```javascript
+```typescript
 interface ProposedCredential {
     "@context": [
         "https://www.w3.org/2018/credentials/v1",
@@ -312,7 +312,7 @@ Since the `AgreedCredential` is not attested, it doesn't contain the `issuanceDa
 The `proof` contains the `type` which is currently limited to `KiltAttestationProofV1` and the `salt` and `commitments`.
 Note that the credential subject MUST be present.
 
-```javascript
+```typescript
 interface AgreedCredential {
     "@context": [
         "https://www.w3.org/2018/credentials/v1",
@@ -349,7 +349,7 @@ interface AgreedCredential {
 
 #### Credential Status
 
-```javascript
+```typescript
 interface CredentialStatus {
     id: string
     type: "KiltRevocationStatusV1"
@@ -358,7 +358,7 @@ interface CredentialStatus {
 
 #### Federated Trust
 
-```javascript
+```typescript
 interface FederatedTrust {
     id: string
     type: "KiltAttesterDelegationV1" | "KiltAttesterLegitimationV1"

--- a/readme.md
+++ b/readme.md
@@ -425,8 +425,11 @@ This `subject` value being provided means that the attester is willing to issue 
 If the `'submit-terms'` message included an unknown DID or none at all as `subject`, the extension MUST ask the user to choose the DID for which the credential will be issued.
 Otherwise, the extension SHOULD NOT offer the choice, but still MUST get the user’s consent to use this DID.
 
+The extension MUST generate the `salt` values according to the [KiltAttestationProofV1 specification](https://github.com/KILTprotocol/spec-KiltCredentialV1/blob/main/ProofTypes/KiltAttestationProofV1.md#salt) and provide them in the `request-attestation` message.
+
 The chosen or confirmed DID URI will be submitted as the `subject` field of the `claim` in the `'request-attestation'` message.
 The attester MUST only issue a credential to this DID.
+The attester MUST use the provided `salt` values for the proof of the credential.
 The attester MAY reject the request if this DID is different from the `subject` in the previous `'submit-terms'` message.
 
 
@@ -443,6 +446,10 @@ interface RequestAttestation {
 
         /** contents of the proposed credential */
         contents: object
+
+        /** The salts to use for the KiltAttestationProofV1
+         * @link https://github.com/KILTprotocol/spec-KiltCredentialV1/blob/main/ProofTypes/KiltAttestationProofV1.md#salt */
+        salt: string[]
 
         /** DID URI to issue the credential for */
         subject: string

--- a/readme.md
+++ b/readme.md
@@ -679,8 +679,6 @@ If the `subject` field is absent, all possible credentials can be used.
 The `challenge` MUST be used only once.
 The dApp MUST store a copy of the `challenge` on the server-side to prevent tampering.
 
-DApp and extension MAY start verification workflows after this event.
-
 ```typescript
 interface RequestCredential {
     cTypes: [
@@ -691,7 +689,10 @@ interface RequestCredential {
             /** optional list of DIDs of attesters trusted by this verifier */
             trustedAttesters?: string[]
 
-            /** list of credential attributes which MUST be included when submitting the credential */
+            /**
+             * list of credential attributes which MUST be included when submitting the credential.
+             * The properties are identified using JSONPath.
+             */
             requiredProperties: string[]
         }
     ]
@@ -702,22 +703,13 @@ interface RequestCredential {
     /** 24 random bytes as hexadecimal */
     challenge: string
 }
-
-const exampleRequest: RequestCredential = {
-    "cTypes": [
-        {
-            "cTypeHash": "0x5366521b1cf4497cfe5f17663a7387a87bb8f2c4295d7c40f3140e7ee6afc41b",
-            "trustedAttesters": [
-                "did:kilt:5CqJa4Ct7oMeMESzehTiN9fwYdGLd7tqeirRMpGDh2XxYYyx"
-            ],
-            "requiredProperties": [
-                "name"
-            ]
-        }
-    ],
-    "challenge": "9f1ceac971cce4c61505974f411a9db432949531abe10dde"
-}
 ```
+
+##### Required Properties
+
+The `cTypes.requiredProperties` property specifies which fields of the credential MUST be included in the presentation.
+All fields which are not covered by the selective disclosure scheme are mandatory and MUST not be listed in the `requiredProperties`.
+
 
 #### 2. Extension or dApp sends credential
 

--- a/readme.md
+++ b/readme.md
@@ -738,9 +738,8 @@ All fields which are not covered by the selective disclosure scheme are mandator
 The extension MUST only send the credential with active consent of the user.
 This is the first step where the user’s DID is revealed to the dApp.
 
-The `challenge` from the previous message MUST be used to create the [verifiable presentation](https://www.w3.org/TR/vc-data-model/#presentations-0)
-with the private key of the identity which owns the credential.
-This prevents replay attacks by confirming the ownership of this identity.
+The `challenge` from the previous message MUST be used to create the [verifiable presentation](https://www.w3.org/TR/vc-data-model/#presentations-0) with the private key of the identity which owns the credential.
+The challenge is added to the data integrity proof which prevents replay attacks by confirming the ownership of this identity.
 
 |              |                       |
 | ------------ | --------------------- |

--- a/readme.md
+++ b/readme.md
@@ -490,10 +490,9 @@ and the recipient address (`attesterAddress`).
 | message_type | `'request-payment'` |
 
 ```typescript
-interface RequestForPayment {
-    /** same as the `rootHash` value of the `'request-attestation'` message */
-    claimHash: string
-}
+/** This message is empty. It should be associated to the terms and quote using the `in-reply-to` field.
+ */
+type RequestForPayment = null
 ```
 
 
@@ -509,9 +508,6 @@ to the attester by sending the `'confirm-payment'` message.
 
 ```typescript
 interface PaymentConfirmation {
-    /** same as the `rootHash` value of the `'request-attestation'` message */
-    claimHash: string
-
     /** hash of the payment transaction */
     txHash: string
 

--- a/readme.md
+++ b/readme.md
@@ -484,9 +484,19 @@ interface Error {
 ```
 
 
-### Attestation Workflow
+### Issuance Workflow
 
-#### 1. Issuer proposes credential
+Issuing a credential follows the following steps:
+
+1. The issuer proposes a credential and requests payment.
+2. The claimer agrees to the terms and pays the requested amount.
+3. The issuer submits the credential to the claimer.
+
+The only mandatory step in this flow is step 3.
+The issuer must submit the credential to the claimer.
+Payment and a signed agreement between the issuer and claimer are optional steps.
+
+#### 1. Optional: Issuer proposes credential
 
 |              |                     |
 | ------------ | ------------------- |
@@ -529,7 +539,7 @@ interface SubmitTerms {
 ```
 
 
-#### 2.a Extension requests credential
+#### 2.a Optional: Extension requests credential
 
 The extension MUST only send the request with active consent of the user.
 This is the first step where the user’s DID is revealed to the dApp.
@@ -638,8 +648,6 @@ The rejection message MUST have the name `rejected-payment`.
 
 If the issuer successfully verified the claim, they MUST issue an attestation and SHOULD send a `submit-credential` message.
 This message contains the attested credential.
-To build the credential, the issuer will generate the salts which are used in the selective disclosure scheme.
-These salts MUST be used only once and be generated using a cryptographic random generator.
 
 |              |                       |
 | ------------ | --------------------- |

--- a/readme.md
+++ b/readme.md
@@ -708,7 +708,7 @@ interface RequestCredential {
             cTypeHash: string
 
             /** optional list of DIDs of issuers trusted by this verifier */
-            trustedissuers?: string[]
+            trustedIssuers?: string[]
 
             /**
              * list of credential attributes which MUST be included when submitting the credential.

--- a/readme.md
+++ b/readme.md
@@ -283,13 +283,13 @@ interface ProposedCredential {
     type: [
         "VerifiableCredential",
         "KiltCredentialV1",
-        "kilt:ctype:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf"
+        `kilt:ctype:${string}`
     ],
     id: string,
     nonTransferable: true,
     credentialSubject: {
         "@context": {
-            "@vocab": "kilt:ctype:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf#"
+            "@vocab": `kilt:ctype:${string}#`
         },
         id?: string,
         [key: string]: any
@@ -321,7 +321,7 @@ interface AgreedCredential {
     type: [
         "VerifiableCredential",
         "KiltCredentialV1",
-        "kilt:ctype:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf"
+        `kilt:ctype:${string}`
     ],
     id: string,
     nonTransferable: true,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# KILT Credential API (Spec version 3.4)
+# KILT Credential API (Spec version 4.0)
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
@@ -35,7 +35,7 @@ interface GlobalKilt {
         /** Versions of the various specifications this dApp adheres to */
         versions: {
             /** MUST equal the version of this specification the dApp adheres to */
-            credentials: '3.4'
+            credentials: '4.0'
         }
     }
 }
@@ -59,7 +59,7 @@ interface InjectedWindowProvider {
     version: string
 
     /** MUST equal the version of this specification the extension adheres to */
-    specVersion: '3.4'
+    specVersion: '4.0'
 }
 
 interface PubSubSession {
@@ -106,12 +106,12 @@ interface EncryptedMessage {
 
 The dApp MUST create the `window.kilt` object as early as possible to indicate its support of the API to the extension.
 This object MUST contain non-enumerable property `meta` being an object with a property `versions`,
-which is in turn an object containing property `credentials` with the value of string `'3.4'`.
+which is in turn an object containing property `credentials` with the value of string `'4.0'`.
 
 ```typescript
 window.kilt = {}
 Object.defineProperty(window.kilt, 'meta', {
-    value: { versions: { credentials: '3.4' } },
+    value: { versions: { credentials: '4.0' } },
     enumerable: false
 })
 ```
@@ -173,7 +173,7 @@ The absence of this value indicates that the dApp uses the Credentials specifica
     },
     name: 'My KILT credentials extension',
     version: '0.0.1',
-    specVersion: '3.4'
+    specVersion: '4.0'
 } as InjectedWindowProvider;
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -327,7 +327,7 @@ interface AgreedCredential {
     nonTransferable: true,
     credentialSubject: {
         "@context": {
-            "@vocab": "kilt:ctype:0xf0fd09f9ed6233b2627d37eb5d6c528345e8945e0b610e70997ed470728b2ebf#"
+            "@vocab": `kilt:ctype:${string}#`
         },
         id: string,
         [key: string]: any

--- a/readme.md
+++ b/readme.md
@@ -214,9 +214,12 @@ Third-party code tampering with these calls is pointless:
 
 ### Data types
 
-Definitions of data types, if not provided here, can be found in
-[the KILTProtocol SDK documentation](https://kiltprotocol.github.io/sdk-js/).
+Some of the data types are not provided inside this specification.
+Refer to the [kilt-extension-api](https://github.com/KILTprotocol/kilt-extension-api) and the [SDK](https://github.com/KILTprotocol/sdk-js) for a definition.
 
+* [IQuote](https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L18)
+* [IQuoteAttesterSigned](https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L30)
+* [IQuoteAgreement](https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L38)
 
 ### Metadata
 
@@ -397,7 +400,7 @@ interface SubmitTerms {
     }
 
     /** optional attester-signed binding
-     *  @link TODO: Update link */
+     *  @link https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L30 */
     quote?: IQuoteAttesterSigned
 
     /** optional ID of the DelegationNode of the attester */
@@ -449,7 +452,8 @@ interface RequestAttestation {
          *  @link https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.VerifiablePresentation.html */
         legitimations: VerifiablePresentation
     },
-    /** quote agreement signed by the claimer */
+    /** quote agreement signed by the claimer 
+     *  @link https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L38 */
     quote?: IQuoteAgreement
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -536,9 +536,10 @@ interface SubmitTerms {
 The extension MUST only send the request with active consent of the user.
 This is the first step where the user’s DID is revealed to the dApp.
 
-The previous message in the flow - `'submit-terms'` - contains the `claim` with an optional `subject` field containing a DID URI.
-This `subject` value being provided means that the issuer is willing to issue the credential for this specific DID.
-If the `'submit-terms'` message included an unknown DID or none at all as `subject`, the extension MUST ask the user to choose the DID for which the credential will be issued.
+The previous message in the flow - `'submit-terms'` - contains an `SubmitTerms` object which has an optional property `/claim/credentialSubject/id`.
+This value being provided means that the issuer is willing to issue the credential for this specific DID.
+If the `'submit-terms'` message included an unknown DID the extension SHOULD respond with the rejection message described in "2.b Extension rejects credential".
+If the property was undefined, the extension MUST ask the user to choose the DID for which the credential will be issued.
 Otherwise, the extension SHOULD NOT offer the choice, but still MUST get the user’s consent to use this DID.
 
 The extension MUST generate the `salt` values according to the [KiltAttestationProofV1 specification](https://github.com/KILTprotocol/spec-KiltCredentialV1/blob/main/ProofTypes/KiltAttestationProofV1.md#salt) and provide them in the `request-attestation` message.

--- a/readme.md
+++ b/readme.md
@@ -273,10 +273,10 @@ After parsing this JSON the recipient MUST ensure that the `sender` field contai
 
 ### Rejections
 
-|||
-|-|-|
-| direction | `extension <-> dApp` |
-| message_type | `'reject'` |
+|              |                      |
+| ------------ | -------------------- |
+| direction    | `extension <-> dApp` |
+| message_type | `'reject'`           |
 
 Rejection messages signal the intentional cancelling of an individual step in the flow.
 
@@ -322,10 +322,10 @@ interface Rejection {
 
 ### Errors
 
-|||
-|-|-|
-| direction | `extension <-> dApp` |
-| message_type | `'error'` |
+|              |                      |
+| ------------ | -------------------- |
+| direction    | `extension <-> dApp` |
+| message_type | `'error'`            |
 
 Error messages signal unintentional programming errors which happened during the processing of the incoming messages
 or when constructing a response message.
@@ -359,10 +359,10 @@ interface Error {
 
 #### 1. Attester proposes credential
 
-|||
-|-|-|
-| direction | `dApp -> extension` |
-| message_type | `'submit-terms'` |
+|              |                     |
+| ------------ | ------------------- |
+| direction    | `dApp -> extension` |
+| message_type | `'submit-terms'`    |
 
 Because of the anticipated multitude of various CTypes, the extension is not expected to provide a UI
 to create and fill in the claims. The role of the extension is to let the user authorize and sign off
@@ -432,9 +432,9 @@ If the `quote` was provided, and the user has entered the password to decrypt th
 the extension SHOULD temporarily cache either the password or the unencrypted private key,
 so that the user does not need to enter it again when the payment needs to be transferred.
 
-|||
-|-|-|
-| direction | `extension -> dApp` |
+|              |                         |
+| ------------ | ----------------------- |
+| direction    | `extension -> dApp`     |
 | message_type | `'request-attestation'` |
 
 ```typescript
@@ -496,9 +496,9 @@ to authorize the transfer of the payment to the attester.
 The previously provided `quote` contains the amount to be paid (`cost.gross`)
 and the recipient address (`attesterAddress`).
 
-|||
-|-|-|
-| direction | `dApp -> extension` |
+|              |                     |
+| ------------ | ------------------- |
+| direction    | `dApp -> extension` |
 | message_type | `'request-payment'` |
 
 ```typescript
@@ -514,9 +514,9 @@ interface RequestForPayment {
 After the user has authorized the payment and it has been transferred, the extension MUST confirm the transfer
 to the attester by sending the `'confirm-payment'` message.
 
-|||
-|-|-|
-| direction | `extension -> dApp` |
+|              |                     |
+| ------------ | ------------------- |
+| direction    | `extension -> dApp` |
 | message_type | `'confirm-payment'` |
 
 ```typescript
@@ -535,9 +535,9 @@ interface PaymentConfirmation {
 
 #### 5. Attester submits credential
 
-|||
-|-|-|
-| direction | `dApp -> extension` |
+|              |                        |
+| ------------ | ---------------------- |
+| direction    | `dApp -> extension`    |
 | message_type | `'submit-attestation'` |
 
 ```typescript
@@ -570,9 +570,9 @@ Once the decision not to approve the attestation request has been made, the atte
 If the corresponding credential is stored in the extension, on receiving this message the extension MUST mark it
 as rejected and SHOULD offer the user the option to remove it.
 
-|||
-|-|-|
-| direction | `dApp -> extension`    |
+|              |                        |
+| ------------ | ---------------------- |
+| direction    | `dApp -> extension`    |
 | message_type | `'reject-attestation'` |
 
 ```typescript
@@ -593,9 +593,9 @@ Repeat for multiple required credentials.
 
 #### 1. DApp or extension requests credential
 
-|||
-|-|-|
-| direction | `dApp <-> extension` |
+|              |                        |
+| ------------ | ---------------------- |
+| direction    | `dApp <-> extension`   |
 | message_type | `'request-credential'` |
 
 Multiple CTypes MAY be requested here only if they can be used interchangeably. For example, if the verifier needs
@@ -663,9 +663,9 @@ This prevents replay attacks by confirming the ownership of this identity.
 The dApp MUST verify in the backend that the `claimerSignature` returned by the extension
 matches its identity and the `challenge`.
 
-|||
-|-|-|
-| direction | `extension <-> dApp` |
+|              |                       |
+| ------------ | --------------------- |
+| direction    | `extension <-> dApp`  |
 | message_type | `'submit-credential'` |
 
 ```typescript

--- a/readme.md
+++ b/readme.md
@@ -415,7 +415,7 @@ interface SubmitTerms {
 ```
 
 
-#### 2. Extension requests credential
+#### 2.a Extension requests credential
 
 The extension MUST only send the request with active consent of the user.
 This is the first step where the user’s DID is revealed to the dApp.
@@ -466,6 +466,10 @@ However, the attester MUST perform checks that the complete data necessary for a
 and properly formatted before sending the `'request-payment'` message or requesting the user to pay via other means.
 If any of the checks have failed, the attester MUST NOT request the payment via any means.
 
+#### 2.b Extension rejects credential
+
+The user might not agree to the terms that the attester proposed.
+If the user rejects the terms, the extension MUST send a [rejection message](#rejections), referencing the `submit-terms` message in the `in-reply-to` field of the message object.
 
 #### 3. Optional: Attester requests payment
 
@@ -496,7 +500,7 @@ type RequestForPayment = null
 ```
 
 
-#### 4. Optional: Extension confirms payment
+#### 4.a Optional: Extension confirms payment
 
 After the user has authorized the payment and it has been transferred, the extension MUST confirm the transfer
 to the attester by sending the `'confirm-payment'` message.
@@ -516,8 +520,12 @@ interface PaymentConfirmation {
 }
 ```
 
+#### 4.b Optional: Extension rejects payment
 
-#### 5. Attester submits credential
+The extension MUST send a [rejection message](#rejections) if the user cancels or rejects the payment.
+
+
+#### 5.a Attester submits credential
 
 If the attester successfully verified the claim, they SHOULD send a `submit-credential` message.
 This message contains the attested credential.
@@ -534,6 +542,16 @@ These salts MUST be used only once and be generated using a cryptographic random
  * @link https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.KiltCredentialV1.html */
 type SubmitCredential = KiltCredentialV1
 ```
+
+#### 5.b Attester rejects credential
+
+In case the attester does not approve the attestation request, no information about this appears on the blockchain.
+The extension can only get this information directly from the attester.
+A rejection message could be useful to help the user to remove the corresponding credential from the extension.
+
+Once the decision not to approve the attestation request has been made, the attester SHOULD send a [rejection message](#rejections).
+If the corresponding credential is stored in the extension, on receiving this message the extension MUST mark it as rejected and SHOULD offer the user the option to remove it.
+
 
 ### Verification Workflow
 

--- a/readme.md
+++ b/readme.md
@@ -428,9 +428,6 @@ The chosen or confirmed DID URI will be submitted as the `owner` field of the `c
 The attester MUST only issue a credential to this DID.
 The attester MAY reject the request if this DID is different from the `owner` in the previous `'submit-terms'` message.
 
-If the `quote` was provided, and the user has entered the password to decrypt the private key for signing the request,
-the extension SHOULD temporarily cache either the password or the unencrypted private key,
-so that the user does not need to enter it again when the payment needs to be transferred.
 
 |              |                         |
 | ------------ | ----------------------- |

--- a/readme.md
+++ b/readme.md
@@ -523,9 +523,7 @@ interface SubmitTerms {
 
     claim: ProposedCredential
 
-    /** optional issuer-signed binding
-     *  @link https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L30 */
-    quote?: IQuote
+    quote?: Quote
     proof: VCDataIntegrity
 }
 ```
@@ -565,9 +563,7 @@ The issuer MAY reject the request if this DID is different from the `subject` in
 ```typescript
 interface RequestAttestation {
     claim: AgreedCredential
-    /** quote agreement signed by the claimer
-     *  @link https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L38 */
-    quote?: IQuote
+    quote?: Quote
     proof: VCDataIntegrity
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -295,7 +295,6 @@ interface ProposedCredential {
     },
     issuer: string,
     federatedTrustModel: FederatedTrust[],
-    credentialStatus: CredentialStatus,
     credentialSchema: {
         id: "ipfs://QmRpbcBsAPLCKUZSNncPiMxtVfM33UBmudaCMQV9K3FD5z",
         type: "JsonSchema2023"

--- a/readme.md
+++ b/readme.md
@@ -250,7 +250,7 @@ interface Message {
     /** ID of the message this message responds to */
     inReplyTo?: string
 
-    /** when this message B is a response to the message A,
+    /** A list of message IDs of previous messages. When this message B is a response to the message A,
      *  B.references = [...A.references, A.inReplyTo] */
     references?: string[]
 }
@@ -538,29 +538,6 @@ These salts MUST be used only once and be generated using a cryptographic random
  * @link https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.KiltCredentialV1.html */
 type SubmitCredential = KiltCredentialV1
 ```
-
-#### 6. Attester rejects attestation
-
-In case the attester does not approve the attestation request, no information about this appears on the blockchain.
-The extension can only get this information directly from the attester.
-A rejection message could be useful to help the user to remove the corresponding credential from the extension.
-
-Once the decision not to approve the attestation request has been made, the attester SHOULD send this message.
-If the corresponding pending credential is stored in the extension, on receiving this message the extension MUST mark it
-as rejected and SHOULD offer the user the option to remove it.
-
-|              |                        |
-| ------------ | ---------------------- |
-| direction    | `dApp -> extension`    |
-| message_type | `'reject-attestation'` |
-
-```typescript
-/** The contents of the message is empty. If multiply attestation requests are pending, the
- * `in-reply-to` field of the message object should be used to associate the rejection with
- * the corresponding request. */
-type AttestationRejection = null
-```
-
 
 ### Verification Workflow
 

--- a/readme.md
+++ b/readme.md
@@ -454,7 +454,7 @@ interface RequestAttestation {
          *  @link https://kiltprotocol.github.io/sdk-js/interfaces/core_src.Types.VerifiablePresentation.html */
         legitimations: VerifiablePresentation
     },
-    /** quote agreement signed by the claimer 
+    /** quote agreement signed by the claimer
      *  @link https://github.com/KILTprotocol/kilt-extension-api/blob/4c0c2f93958ab72b59b72057a6e9b6aedb5fccef/src/types/Quote.ts#L38 */
     quote?: IQuoteAgreement
 }
@@ -539,7 +539,6 @@ These salts MUST be used only once and be generated using a cryptographic random
 type SubmitCredential = KiltCredentialV1
 ```
 
-
 #### 6. Attester rejects attestation
 
 In case the attester does not approve the attestation request, no information about this appears on the blockchain.
@@ -547,7 +546,7 @@ The extension can only get this information directly from the attester.
 A rejection message could be useful to help the user to remove the corresponding credential from the extension.
 
 Once the decision not to approve the attestation request has been made, the attester SHOULD send this message.
-If the corresponding credential is stored in the extension, on receiving this message the extension MUST mark it
+If the corresponding pending credential is stored in the extension, on receiving this message the extension MUST mark it
 as rejected and SHOULD offer the user the option to remove it.
 
 |              |                        |
@@ -556,8 +555,10 @@ as rejected and SHOULD offer the user the option to remove it.
 | message_type | `'reject-attestation'` |
 
 ```typescript
-/** The contents of the message is simply the `rootHash` of the credential */
-type AttestationRejection = string
+/** The contents of the message is empty. If multiply attestation requests are pending, the
+ * `in-reply-to` field of the message object should be used to associate the rejection with
+ * the corresponding request. */
+type AttestationRejection = null
 ```
 
 


### PR DESCRIPTION
## fixes KILTprotocol/ticket/issues/2338

* Update the spec to use the new VCs
* related to https://github.com/KILTprotocol/sdk-js/pull/807

### Changes:

* rename `owner` to `subject`
* VCs instead of classic KILT credential
  * ClaimHash will only be known after successful attestation
  * reject attestation can't refer to the rootHash (not yet known). use the `in-reply-to` field of the message layer to refer to the rejected request.
  * timestamp might be queried from an indexer or from the `submit-credential` message
* remove `attestation-rejection`: there is already a rejection message type
  * explicitly mention the rejection flow for steps where it makes sense.
* remove claim-hash from `RequestForPayment` and `PaymentConfirmation`. use the `in-reply-to` field of the message layer to refer to the paid credential request.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
